### PR TITLE
change action mapping fn context to the stamp

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -31,11 +31,12 @@ export function getActionDef(ctx) {
 export function create({ name, map }) {
   let observers = [];
   let actionStart = new Rx.Subject();
+  let boundMap = map.bind(this);
 
   function action(value) {
     let err = null;
     try {
-      value = map(value);
+      value = boundMap(value);
     } catch(e) {
       err = e;
     }
@@ -76,9 +77,9 @@ export function create({ name, map }) {
   return action;
 }
 
-export function createMany() {
+export function createMany(instance) {
   return this
-    .map(create)
+    .map(create, instance)
     .reduce((ctx, action) => {
       ctx[action.displayName] = action;
       return ctx;
@@ -89,7 +90,7 @@ export default function Actions(obj = {}) {
   return stampit()
     .refs({ displayName: obj.displayName })
     .init(({ instance }) => {
-      const actionMethods = getActionDef(obj)::createMany();
+      const actionMethods = getActionDef(obj)::createMany(instance);
       return stampit.mixin(instance, actionMethods);
     });
 }

--- a/test/action.js
+++ b/test/action.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import Rx from 'rx';
+import stampit from 'stampit';
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
@@ -61,6 +62,34 @@ describe('Actions', function() {
         done();
       });
       catActions.getInBox('human');
+    });
+
+    it('should bind original map function to the stamp', function(done) {
+      const mixin = stampit().methods({
+        getResult() {
+          return true;
+        }
+      });
+
+      const ComposedActions = Actions({
+        displayName: 'composedActions',
+
+        perform() {
+          this.should.be.defined;
+          this.getResult.should.be.a( 'function' );
+
+          return {
+            result: this.getResult()
+          };
+        }
+      }).compose( mixin );
+      let composedActions = ComposedActions();
+
+      composedActions.perform.subscribe(function(value) {
+        value.result.should.be.true;
+        done();
+      });
+      composedActions.perform();
     });
 
     it(


### PR DESCRIPTION
Allows accessing composed methods and properties from within action mapping functions using `this`.

Closes #77
